### PR TITLE
fix: exit after creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ const brandColor = /** @type {const} */ ([174, 128, 255]);
 	}
 
 	prompts.outro(kl.green(`You're all set!`));
+	process.exit(0)
 })();
 
 /**


### PR DESCRIPTION
We are currently `^C` manually after creation.

![Screenshot 2024-04-10 at 12 45 42 AM](https://github.com/preactjs/create-preact/assets/120007119/0b20ac0e-4244-4b89-b7bf-fc8b997849fe)
