### PR TITLE
fix: get package manager

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,7 @@ const brandColor = /** @type {const} */ ([174, 128, 255]);
 	//
 	// Don't love the flag, need to find a better name.
 	const skipHint = process.argv.slice(2).includes('--skip-hints');
-	const packageManager = /yarn/.test(process.env.npm_execpath)
-		? 'yarn'
-		: process.env.PNPM_PACKAGE_NAME
-		? 'pnpm'
-		: 'npm';
+	const packageManager = getPkgManager();
 
 	prompts.intro(
 		kl.trueColor(...brandColor)(
@@ -251,4 +247,15 @@ function installPackages(pkgs, opts) {
 			cwd: opts.to,
 		},
 	);
+}
+
+/**
+ *
+ * @returns {'yarn' | 'pnpm' | 'npm'}
+ */
+function getPkgManager() {
+  const userAgent = process.env.npm_config_user_agent || ''
+  if (userAgent.startsWith('yarn')) return 'yarn'
+  if (userAgent.startsWith('pnpm')) return 'pnpm'
+  return 'npm'
 }

--- a/src/index.js
+++ b/src/index.js
@@ -250,7 +250,6 @@ function installPackages(pkgs, opts) {
 }
 
 /**
- *
  * @returns {'yarn' | 'pnpm' | 'npm'}
  */
 function getPkgManager() {


### PR DESCRIPTION
cc @rschristian 

This PR added the get package manager method, which looks for process.env of `npm_config_user_agent`.
This method is supported for yarn, npm, and pnpm.

P.S.  `create-next-app` also uses [this method](https://github.com/vercel/next.js/blob/5e2ac0986f78c8e15756ec403666d20a99d3247e/packages/create-next-app/helpers/get-pkg-manager.ts)

x-ref: https://github.com/pnpm/pnpm/pull/4317
x-ref: https://github.com/npm/cli/pull/1919
x-ref: https://github.com/yarnpkg/yarn/pull/7127
x-ref: [stackoverflow](https://stackoverflow.com/questions/68133683/is-there-a-cross-platform-way-to-get-the-name-of-the-parent-process-in-node-js)