### PR TITLE
refactor: Switch to tinyexec to reduce install size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^0.6.3",
-				"execa": "^8.0.1",
-				"kolorist": "^1.8.0"
+				"kolorist": "^1.8.0",
+				"tinyexec": "^0.3.1"
 			},
 			"bin": {
 				"create-preact": "src/index.js"
@@ -67,156 +67,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/execa": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^7.0.3",
-				"get-stream": "^8.0.1",
-				"human-signals": "^5.0.0",
-				"is-stream": "^3.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^5.1.0",
-				"onetime": "^6.0.0",
-				"signal-exit": "^4.1.0",
-				"strip-final-newline": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.17"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/get-stream": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/human-signals": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=16.17.0"
-			}
-		},
-		"node_modules/is-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"license": "ISC"
-		},
 		"node_modules/kolorist": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
 			"integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
 			"license": "MIT"
-		},
-		"node_modules/merge-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"license": "MIT"
-		},
-		"node_modules/mimic-fn": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm-run-path": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm-run-path/node_modules/path-key": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/onetime": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-			"license": "MIT",
-			"dependencies": {
-				"mimic-fn": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
@@ -261,56 +116,17 @@
 				"prettier": "2.x"
 			}
 		},
-		"node_modules/shebang-command": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"license": "MIT"
 		},
-		"node_modules/strip-final-newline": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
+		"node_modules/tinyexec": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
+			"integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
+			"license": "MIT"
 		},
 		"node_modules/typescript": {
 			"version": "5.0.4",
@@ -324,21 +140,6 @@
 			},
 			"engines": {
 				"node": ">=12.20"
-			}
-		},
-		"node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
 	],
 	"dependencies": {
 		"@clack/prompts": "^0.6.3",
-		"execa": "^8.0.1",
-		"kolorist": "^1.8.0"
+		"kolorist": "^1.8.0",
+		"tinyexec": "^0.3.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20.2.3",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { promises as fs, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as prompts from '@clack/prompts';
-import { execa } from 'execa';
+import { x } from 'tinyexec';
 import * as kl from 'kolorist';
 
 const s = prompts.spinner();
@@ -238,7 +238,7 @@ async function installDeps(to, opts) {
  * @param {{ packageManager: 'yarn' | 'pnpm' | 'npm', to: string, dev?: boolean }} opts
  */
 function installPackages(pkgs, opts) {
-	return execa(
+	return x(
 		opts.packageManager,
 		[
 			// `yarn add` will fail if nothing is provided
@@ -247,8 +247,10 @@ function installPackages(pkgs, opts) {
 			...pkgs,
 		].filter(Boolean),
 		{
-			stdio: 'ignore',
-			cwd: opts.to,
+			nodeOptions: {
+				stdio: 'ignore',
+				cwd: opts.to,
+			}
 		},
 	);
 }


### PR DESCRIPTION
Drops the install size from 686kb to 225kb -- not a massive change in context, but for a project initializer, might have some merit.